### PR TITLE
SRW-24: add user level logging

### DIFF
--- a/internal/lambdahost/host.go
+++ b/internal/lambdahost/host.go
@@ -45,10 +45,11 @@ func (h *LambdaHost) send(ins instruction) {
 	h.events <- ins
 }
 
-func (h *LambdaHost) Run(ctx context.Context, done chan<- struct{}) error {
+func (h *LambdaHost) Run(ctx context.Context, done chan<- struct{}, runWg *sync.WaitGroup) error {
 	if err := h.runContainer(ctx); err != nil {
 		return fmt.Errorf("running containers: %w", err)
 	}
+	runWg.Done()
 
 	for ins := range h.events {
 		logger := log.With().Interface("instruction", ins).Logger()

--- a/internal/lambdahost/host_test.go
+++ b/internal/lambdahost/host_test.go
@@ -54,7 +54,9 @@ func TestShutdown(t *testing.T) {
 	client := &mockClient{}
 	host := New(client, args)
 	done := make(chan struct{})
-	go host.Run(ctx, done)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go host.Run(ctx, done, &wg)
 	host.Shutdown()
 	<-done
 
@@ -79,7 +81,9 @@ func TestRestart(t *testing.T) {
 	client := &mockClient{}
 	host := New(client, args)
 	done := make(chan struct{})
-	go host.Run(ctx, done)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go host.Run(ctx, done, &wg)
 	host.Restart()
 	host.Shutdown()
 	<-done

--- a/main.go
+++ b/main.go
@@ -260,7 +260,6 @@ func main() {
 		// special error handling - the flags package prints the help for us
 		os.Exit(1)
 	}
-	log.Debug().Interface("opts", opts).Msg("parsed command line options")
 
 	switch len(opts.Verbose) {
 	case 0:
@@ -270,6 +269,8 @@ func main() {
 	default:
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}
+
+	log.Debug().Interface("opts", opts).Msg("parsed command line options")
 
 	ctx := context.TODO()
 	if err := run(ctx, opts); err != nil {

--- a/main.go
+++ b/main.go
@@ -244,11 +244,11 @@ func main() {
 
 	switch len(opts.Verbose) {
 	case 0:
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	case 1:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	default:
+	case 1:
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	default:
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}
 
 	ctx := context.TODO()

--- a/main.go
+++ b/main.go
@@ -134,9 +134,9 @@ type Args struct {
 }
 
 type Opts struct {
-		Verbose []bool `short:"v" long:"verbose" description:"Print verbose logging output"`
-		RootDir string `short:"r" long:"root" description:"Unpacked root directory" required:"yes"`
-		Args    Args `positional-args:"yes" required:"yes"`
+	Verbose []bool `short:"v" long:"verbose" description:"Print verbose logging output"`
+	RootDir string `short:"r" long:"root"    description:"Unpacked root directory"      required:"yes"`
+	Args    Args   `                                                                    required:"yes" positional-args:"yes"`
 }
 
 func run(ctx context.Context, opts Opts) error {


### PR DESCRIPTION
- Set info level logging to be the default
- Minor formatting
- Print information for the user
- Move debug log to after we configure the global logging level
- Add wait group before printing
